### PR TITLE
Address update

### DIFF
--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -24,6 +24,21 @@ class User::AddressesController < ApplicationController
     end
   end
 
+  def edit
+    @address = Address.find(params[:address_id])
+  end
+
+  def update
+    @address = Address.find(params[:address_id])
+    if @address.update(address_params)
+      flash[:success] = "Your address has been updated!"
+      redirect_to "/profile/addresses/#{@address.id}"
+    else
+      flash.now[:error] = @address.errors.full_messages.to_sentence
+      render :edit
+    end
+  end
+
   private
     def address_params
       params.permit(:nickname, :name, :street_address, :city, :state, :zip)

--- a/app/views/user/addresses/edit.html.erb
+++ b/app/views/user/addresses/edit.html.erb
@@ -1,0 +1,23 @@
+<h1>Edit <%= @address.nickname %></h1>
+
+<%= form_tag "/profile/addresses/#{@address.id}", method: :patch do %>
+  <%= label_tag :nickname %>
+  <%= text_field_tag :nickname, @address.nickname %>
+
+  <%= label_tag :name %>
+  <%= text_field_tag :name, @address.name %>
+
+  <%= label_tag :street_address %>
+  <%= text_field_tag :street_address, @address.street_address %>
+
+  <%= label_tag :city %>
+  <%= text_field_tag :city, @address.city %>
+
+  <%= label_tag :state %>
+  <%= text_field_tag :state, @address.state %>
+
+  <%= label_tag :zip %>
+  <%= text_field_tag :zip, @address.zip %>
+
+  <%= submit_tag 'Update Address' %>
+<% end %>

--- a/app/views/user/addresses/show.html.erb
+++ b/app/views/user/addresses/show.html.erb
@@ -2,3 +2,4 @@
 <p>Name: <%= @address.name %></p>
 <p><%= @address.street_address %></p>
 <p><%= "#{@address.city} #{@address.state} #{@address.zip}" %></p>
+<p><%= link_to 'Edit Address', "/profile/addresses/#{@address.id}/edit" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,9 @@ Rails.application.routes.draw do
   get '/profile/addresses', to: 'user/addresses#index'
   get '/profile/addresses/new', to: 'user/addresses#new'
   get '/profile/addresses/:address_id', to: 'user/addresses#show'
+  get '/profile/addresses/:address_id/edit', to: 'user/addresses#edit'
   post '/profile/addresses', to: 'user/addresses#create'
+  patch '/profile/addresses/:address_id', to: 'user/addresses#update'
 
   namespace :merchant do
     get '/', to: 'dashboard#index', as: :dashboard

--- a/spec/features/addresses/update_spec.rb
+++ b/spec/features/addresses/update_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'User addresses can be updated' do
+  describe 'As a user, when I visit an address show page' do
+    before(:each) do
+      @user = User.create(name: 'Ryan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'ryan@example.com', password: 'securepassword')
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      @address_1 = Address.create(nickname: 'Home', name: 'Ryan Hantak', street_address: '123 A Street', city: 'Dallas', state: 'TX', zip: '75070', user_id: @user.id)
+
+      visit '/profile'
+      click_link 'My Addresses'
+      within "#address-#{@address_1.id}" do
+        click_link "#{@address_1.nickname}"
+      end
+    end
+
+    it "I see a link to edit the address" do
+      click_link 'Edit Address'
+      expect(current_path).to eq("/profile/addresses/#{@address_1.id}/edit")
+    end
+
+    it "I am brought to a form where I can change any info on the address" do
+      click_link 'Edit Address'
+
+      fill_in :nickname, with: "Turing"
+      fill_in :name, with: "Ryan Hantak"
+      fill_in :street_address, with: "1331 Market Street"
+      fill_in :city, with: "Denver"
+      fill_in :state, with: "CO"
+      fill_in :zip, with: "80202"
+
+      click_button 'Update Address'
+
+      expect(current_path).to eq("/profile/addresses/#{@address_1.id}")
+
+      expect(page).to have_content("Turing")
+      expect(page).to have_content("Ryan Hantak")
+      expect(page).to have_content("1331 Market Street")
+      expect(page).to have_content("Denver")
+      expect(page).to have_content("CO")
+      expect(page).to have_content("80202")
+    end
+
+    it "If I leave fields blank, I see error messages" do
+      click_link 'Edit Address'
+
+      fill_in :nickname, with: ""
+      fill_in :name, with: ""
+      fill_in :street_address, with: ""
+      fill_in :city, with: ""
+      fill_in :state, with: ""
+      fill_in :zip, with: ""
+
+      click_button 'Update Address'
+
+      expect(page).to have_content("Nickname can't be blank, Name can't be blank, Street address can't be blank, City can't be blank, State can't be blank, and Zip can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
- Users now see a link to edit an address on their address show page
- Add a page containing a form which users can use to update an address
- If users leave a field blank they will see a corresponding error message