### PR TITLE
Order change address

### DIFF
--- a/app/controllers/user/orders_controller.rb
+++ b/app/controllers/user/orders_controller.rb
@@ -9,6 +9,17 @@ class User::OrdersController < ApplicationController
     @order = current_user.orders.find(params[:id])
   end
 
+  def edit
+    @order = Order.find(params[:order_id])
+    @address_options = current_user.addresses.map{ |add| [ add.nickname, add.id ] }
+  end
+
+  def update
+    order = Order.find(params[:order_id])
+    order.update(order_params)
+    redirect_to "/profile/orders/#{order.id}"
+  end
+
   def create
     order = current_user.orders.new(order_params)
     order.save

--- a/app/views/user/orders/edit.html.erb
+++ b/app/views/user/orders/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Change Order Address</h1>
+<%= form_tag "/profile/orders/#{@order.id}", method: :patch do %>
+  <%= select(:order, :address_id, @address_options) %>
+  <%= submit_tag 'Change Address' %>
+<% end %>

--- a/app/views/user/orders/show.html.erb
+++ b/app/views/user/orders/show.html.erb
@@ -1,10 +1,15 @@
 <h2>Order <%= @order.id %></h2>
+<p><%= @order.address.street_address %></p>
+<p><%= "#{@order.address.city}, #{@order.address.state}, #{@order.address.zip}" %></p>
 <p>Created On: <%= @order.created_at %></p>
 <p>Updated On: <%= @order.updated_at %></p>
 <p>Status: <%= @order.status %></p>
 <p><%= @order.count_of_items %> items</p>
 <p>Total: <%= number_to_currency(@order.grand_total) %></p>
 <%= button_to 'Cancel Order', "/profile/orders/#{@order.id}", method: :delete if @order.pending? %>
+<% if @order.status != 'shipped' %>
+  <%= link_to 'Edit Order', "/profile/orders/#{@order.id}/edit" %>
+<% end %>
 
 <h2>Order Items</h2>
 <% @order.order_items.each do |order_item| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
   post '/orders', to: 'user/orders#create'
   get '/profile/orders', to: 'user/orders#index'
   get '/profile/orders/:id', to: 'user/orders#show'
+  get '/profile/orders/:order_id/edit', to: 'user/orders#edit'
+  patch '/profile/orders/:order_id', to: 'user/orders#update'
   delete '/profile/orders/:id', to: 'user/orders#cancel'
 
   get '/login', to: 'sessions#new'

--- a/spec/features/user/orders/edit_spec.rb
+++ b/spec/features/user/orders/edit_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'Edit order' do
+  describe 'As a registered user' do
+    describe 'When I vist an order show page' do
+      before(:each) do
+        @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+        @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+        @user = User.create!(name: 'Megan', email: 'megan_1@example.com', password: 'securepassword')
+        @address_1 = Address.create!(nickname: 'Home', name: 'Megan', street_address: '123 A Street', city: 'Dallas', state: 'TX', zip: '75070', user_id: @user.id)
+        @address_2 = Address.create!(nickname: 'New Address', name: 'Megan', street_address: '234 Street', city: 'Denver', state: 'CO', zip: '80202', user_id: @user.id)
+        @order_1 = @user.orders.create!(status: "packaged", address_id: @address_1.id)
+        @order_item_1 = @order_1.order_items.create!(item: @ogre, price: @ogre.price, quantity: 2, fulfilled: true)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+        visit '/profile'
+        click_link 'My Orders'
+        click_link "#{@order_1.id}"
+      end
+
+      it "I see a link to edit the order if it is not shipped" do
+        click_link 'Edit Order'
+
+        expect(current_path).to eq("/profile/orders/#{@order_1.id}/edit")
+      end
+
+      it "I don't see an edit link if the order has shipped" do
+        @order_1.update(status: 'shipped')
+        visit '/profile'
+        click_link 'My Orders'
+        click_link "#{@order_1.id}"
+
+        expect(page).to_not have_link('Edit Order')
+      end
+
+      it "I can select an option for a new address" do
+        click_link 'Edit Order'
+
+        find('#order_address_id').find(:xpath, 'option[2]').select_option
+
+        click_button 'Change Address'
+
+        visit '/profile/orders'
+        click_link "#{@order_1.id}"
+        expect(page).to have_content(@address_2.street_address)
+        expect(page).to have_content(@address_2.city)
+        expect(page).to have_content(@address_2.state)
+        expect(page).to have_content(@address_2.zip)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Users can use a link on order show page to change the address associated with an order (if the order hasn't shipped)
